### PR TITLE
Updated deployment key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 sudo: false
 
 php:
-  - 7.1
+  - 7.3
 
 before_script:
   - curl -LSs https://box-project.github.io/box2/installer.php | php


### PR DESCRIPTION
We've attached a machine user to this repo (limit to only this repo, for security reasons), roughly following this guide, but with exceptions: https://docs.travis-ci.com/user/deployment/releases/#authenticating-with-an-oauth-token
- I was unable to use `travis setup releases` because it required logging in as the machine user from the CLI, which I guess was hard
- Instead, I manually created an access token on the machine user with repo scope. Auth with sso.
- Authenticate with `travis login --pro`, I had to use a new personal token created just for this purpose since native auth seemed broken. Authenticate as _yourself_ (it's okay to auth as yourself instead of machine user, because Travis encrypts with a private key attached to the repo, not attached to the particular user).
- Do `travis encrypt [token] --pro`. Super important to use `--pro` and _not_ give the token a "name" as you would for an env var.
5. Add to .travis.yml as here.